### PR TITLE
Update gem to fix for obsolete URI escape and unescape methods

### DIFF
--- a/lib/http_router/generator.rb
+++ b/lib/http_router/generator.rb
@@ -36,13 +36,13 @@ class HttpRouter
             instance_eval <<-EOT, __FILE__, __LINE__ + 1
             def generate(args, options)
               generated_path = \"#{code}\"
-              #{validation_regex.inspect}.match(generated_path) ? URI.escape(generated_path) : nil
+              #{validation_regex.inspect}.match(generated_path) ? URI::DEFAULT_PARSER.escape(generated_path) : nil
             end
             EOT
           else
             instance_eval <<-EOT, __FILE__, __LINE__ + 1
             def generate(args, options)
-              URI.escape(\"#{code}\")
+              URI::DEFAULT_PARSER.escape(\"#{code}\")
             end
             EOT
           end

--- a/lib/http_router/request.rb
+++ b/lib/http_router/request.rb
@@ -7,7 +7,7 @@ class HttpRouter
 
     def initialize(path, rack_request)
       @rack_request = rack_request
-      @path = URI.unescape(path).split(/\//)
+      @path = URI::DEFAULT_PARSER.unescape(path).split(/\//)
       @path.shift if @path.first == ''
       @path.push('') if path[-1] == ?/
       @extra_env = {}


### PR DESCRIPTION
In order to remove the warnings about the use of URI#unescape and
URI#escape, this pull request updates the mentioned methods to use
`URI::DEFAULT_PARSER`.